### PR TITLE
Updates 7A and 7B figures for panels

### DIFF
--- a/kda_analysis/emre/fig_7a.py
+++ b/kda_analysis/emre/fig_7a.py
@@ -177,7 +177,7 @@ def sub_dict_7a_symbols():
         k42: H_on * H_out,
         k24: H_off,
         k68: H_on * H_in,
-        k86: D_off,
+        k86: H_off,
         k34: D_on * D_out,
         k43: D_off,
         k56: D_on * D_in,
@@ -246,7 +246,7 @@ def sub_dict_7a_values():
         k42: H_on * H_out,
         k24: H_off,
         k68: H_on * H_in,
-        k86: D_off,
+        k86: H_off,
         k34: D_on * c_D,
         k43: D_off,
         k56: D_on * c_D,
@@ -270,7 +270,10 @@ def sub_dict_7a_values():
 def plot_fig_7A(df):
     main_fig_width = 3.25 # inches
     main_fig_height = 4.25 # inches
-    legend_width = 0.8125 # inches
+    legend_width = 0.85 # inches
+    legend_height = 1.0 # inches
+    fig_leg = plt.figure(figsize=(legend_width, legend_height), tight_layout=True)
+    ax_leg = fig_leg.add_subplot(111)
     fig = plt.figure(figsize=(main_fig_width, main_fig_height), tight_layout=True)
     ax = fig.add_subplot(211)
 
@@ -302,4 +305,4 @@ def plot_fig_7A(df):
         ls="--",
         color="black",
     )
-    return fig, [ax]
+    return fig, [ax, ax_leg]

--- a/kda_analysis/emre/fig_7a.py
+++ b/kda_analysis/emre/fig_7a.py
@@ -268,7 +268,10 @@ def sub_dict_7a_values():
 
 
 def plot_fig_7A(df):
-    fig = plt.figure(figsize=(4, 4), tight_layout=True)
+    main_fig_width = 3.25 # inches
+    main_fig_height = 4.25 # inches
+    legend_width = 0.8125 # inches
+    fig = plt.figure(figsize=(main_fig_width, main_fig_height), tight_layout=True)
     ax = fig.add_subplot(211)
 
     column_keys = df.columns

--- a/kda_analysis/emre/fig_7b.py
+++ b/kda_analysis/emre/fig_7b.py
@@ -231,9 +231,10 @@ def rect_label(color):
 def plot_fig_7B(df, colors):
 
     main_fig_width = 3.25 # inches
-    legend_width = 1 # inches
     main_fig_height = 4.25 # inches
-    fig_leg = plt.figure(figsize=(legend_width, main_fig_height), tight_layout=True)
+    legend_width = 0.85 # inches
+    legend_height = 1.1 # inches
+    fig_leg = plt.figure(figsize=(legend_width, legend_height), tight_layout=True)
     ax_leg = fig_leg.add_subplot(111)
     fig = plt.figure(figsize=(main_fig_width, main_fig_height), tight_layout=True)
     axH = fig.add_subplot(311)
@@ -252,24 +253,17 @@ def plot_fig_7B(df, colors):
 
     linewidth = 0.6
 
-    axH.axvline(
-        x=1,
-        ymin=0,
-        ymax=1,
-        ls="--",
-        lw=0.8,
-        color="black",
-        label=r"$R_\mathrm{off}$ = 1",
-    )
-    axD.axvline(
-        x=1,
-        ymin=0,
-        ymax=1,
-        ls="--",
-        lw=0.8,
-        color="black",
-        label=r"$R_\mathrm{off}$ = 1",
-    )
+    for _ax in (axH, axD):
+        _ax.axvline(
+            x=1,
+            ymin=0,
+            ymax=1,
+            ls="--",
+            lw=0.8,
+            color="black",
+            # label=r"$R_\mathrm{off}$ = 1",
+        )
+    axD.set_ylim(-0.11, 0.11)
 
     rect_handles = [rect_label(color="black")]
     for i, val in enumerate(unique_k_AA):
@@ -298,17 +292,24 @@ def plot_fig_7B(df, colors):
     axD.set_ylabel(r"Drug Flux (s$^{-1}$)")
 
     _, labels = axH.get_legend_handles_labels()
+    new_labels = []
+    for _label in labels:
+        if _label == "100":
+            _label = r"$\bf{100}$"
+        new_labels.append(_label)
     ax_leg.axis("off")
     ax_leg.legend(
         rect_handles[::-1],
-        labels[::-1],
+        new_labels[::-1],
         bbox_to_anchor=(0.5, 0.5),
         loc="center",
         title=r"$k_\mathrm{AA}$ (s$^{-1}$)",
         handlelength=1,
         handleheight=1,
     )
-    fig_leg.savefig("plots/figures/fig_7B_legend.png", dpi=300)
+    for _ext in ("png", "pdf", "svg"):
+        fig_leg.savefig(f"plots/figures/fig_7B_legend.{_ext}", dpi=300)
+
 
     max_power = np.max(np.log10(R_off_data))
     xticks = np.logspace(-max_power, max_power, 9)

--- a/kda_analysis/emre/fig_7b.py
+++ b/kda_analysis/emre/fig_7b.py
@@ -230,17 +230,14 @@ def rect_label(color):
 
 def plot_fig_7B(df, colors):
 
-    fig = plt.figure(figsize=(4, 4), tight_layout=True)
-    ax = fig.add_subplot(111)  # big subplot
+    main_fig_width = 3.25 # inches
+    legend_width = 1 # inches
+    main_fig_height = 4.25 # inches
+    fig_leg = plt.figure(figsize=(legend_width, main_fig_height), tight_layout=True)
+    ax_leg = fig_leg.add_subplot(111)
+    fig = plt.figure(figsize=(main_fig_width, main_fig_height), tight_layout=True)
     axH = fig.add_subplot(311)
     axD = fig.add_subplot(312, sharex=axH)
-
-    # Turn off axis lines and ticks of the big subplot
-    ax.spines["top"].set_color("none")
-    ax.spines["bottom"].set_color("none")
-    ax.spines["left"].set_color("none")
-    ax.spines["right"].set_color("none")
-    ax.tick_params(labelcolor="w", top=False, bottom=False, left=False, right=False)
 
     column_keys = df.columns
     H_flux_key = column_keys[-2]
@@ -301,15 +298,17 @@ def plot_fig_7B(df, colors):
     axD.set_ylabel(r"Drug Flux (s$^{-1}$)")
 
     _, labels = axH.get_legend_handles_labels()
-    ax.legend(
+    ax_leg.axis("off")
+    ax_leg.legend(
         rect_handles[::-1],
         labels[::-1],
-        bbox_to_anchor=(1, 0.5),
-        loc="center left",
+        bbox_to_anchor=(0.5, 0.5),
+        loc="center",
         title=r"$k_\mathrm{AA}$ (s$^{-1}$)",
         handlelength=1,
         handleheight=1,
     )
+    fig_leg.savefig("plots/figures/fig_7B_legend.png", dpi=300)
 
     max_power = np.max(np.log10(R_off_data))
     xticks = np.logspace(-max_power, max_power, 9)

--- a/kda_analysis/emre/generate_figures.py
+++ b/kda_analysis/emre/generate_figures.py
@@ -78,7 +78,7 @@ def main(fig_list, check_thermo_con):
             ):
                 save_path = f"plots/flux_graphs/{filename}"
                 print(f"--> Saving Fig. {fig_key} at location: {save_path}")
-                flux_graph.savefig(save_path, dpi=300, bbox_inches="tight")
+                flux_graph.savefig(save_path, dpi=300)
                 plt.close()
 
 

--- a/kda_analysis/emre/generate_figures.py
+++ b/kda_analysis/emre/generate_figures.py
@@ -65,9 +65,10 @@ def main(fig_list, check_thermo_con):
         )
 
         fig = fig_utils.plot_data(df=plot_df, fig_key=fig_key)
-        save_path = f"plots/figures/fig_{fig_key}.png"
-        print(f"--> Saving Fig. {fig_key} at location: {save_path}")
-        plt.savefig(save_path, dpi=300)
+        save_path = f"plots/figures/fig_{fig_key}"
+        print(f"--> Saving Fig. {fig_key} at location: {save_path}...")
+        for _ext in ("png", "pdf", "svg"):
+            fig.savefig(f"{save_path}.{_ext}", dpi=300)
         plt.close()
 
         supported_figs = ["7A", "7B"]
@@ -77,8 +78,9 @@ def main(fig_list, check_thermo_con):
                 zip(data_dict["figures"], data_dict["filenames"])
             ):
                 save_path = f"plots/flux_graphs/{filename}"
-                print(f"--> Saving Fig. {fig_key} at location: {save_path}")
-                flux_graph.savefig(save_path, dpi=300)
+                print(f"--> Saving Fig. {fig_key} at location: {save_path}...")
+                for _ext in ("png", "pdf", "svg"):
+                    flux_graph.savefig(f"{save_path}.{_ext}", dpi=300)
                 plt.close()
 
 

--- a/kda_analysis/emre/operational_flux.py
+++ b/kda_analysis/emre/operational_flux.py
@@ -236,7 +236,7 @@ def get_op_cycle_flux_funcs(
         function was generated from the simplified SymPy expression.
     """
     # get the directional partial diagram (edges)
-    dir_par_edges = diagrams.generate_directional_partial_diagrams(G, return_edges=True)
+    dir_par_edges = diagrams.generate_directional_diagrams(G, return_edges=True)
     # use the directional partial diagram info to calculate sigma (normalization)
     sigma_str = calculations.calc_sigma(G, dir_par_edges, key=key, output_strings=True)
     # initialize an empty list for storing net cycle flux numerators


### PR DESCRIPTION
* Saves figures without `bbox_inches="tight"`

* Saves figures 7A and 7B at-size

* Saves figure 7B legend separately. No longer generates an empty canvas subplot.

* Saves figures 7A and 7B flux diagrams at-size, separately from their legends

* Updates `fmt_scientific` to output more concise expressions

* Fixes remaining non-italicized flux variables

* Saves all figures as `.png`, `.svg`, and `.pdf`

* Fixes k86 variable substitution issue. k86 in EmrE paper is
shown to have values of H_off when indeed they should be D_off.
This carried through to the variable subs in `fig_7a.py`,
which now correctly assign H_off.

* Changes Roff flux diagrams to generate only the diagrams for
kAA = 100 and Roff = 1e-10, 1e0, 1e2

* Changes net transition flux threshold for transition
flux diagrams to 0.02 instead of 0.1

* Fixes function call signature error in `operational_flux.py`